### PR TITLE
Update mkdir process for multiple dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,9 @@ venv.bak/
 .mypy_cache/
 
 .idea
+
+# exclude targets folder
+targets/*
+
+# keep the gitkeep
+!targets/.gitkeep

--- a/recon/targets.py
+++ b/recon/targets.py
@@ -50,9 +50,10 @@ class TargetList(luigi.ExternalTask):
             # no exception thrown; ip address found
             with_suffix = self.target_file.with_suffix(".ips")
 
-        self.results_dir.mkdir(parents=True, exist_ok=True)
 
         with_suffix = (Path(self.results_dir) / with_suffix).resolve()
+
+        with_suffix.parent.mkdir(parents=True, exist_ok=True)
 
         # copy file with new extension
         shutil.copy(self.target_file, with_suffix)


### PR DESCRIPTION
Add targets folder; refactor the mkdir process in order to account for the possibilities of multiple directories in the target-file name