### PR TITLE
Fixed `status` default value

### DIFF
--- a/recon/__init__.py
+++ b/recon/__init__.py
@@ -178,7 +178,7 @@ status_parser.add_argument(
 status_parser.add_argument(
     "--host",
     help="host on which the luigi central scheduler's visualization site is running (default: localhost)",
-    default="localhost",
+    default="127.0.0.1",
 )
 
 


### PR DESCRIPTION
On ubuntu, localhost wasn't directing the browswer properly, resulting in a blank URL line.  Default is now 127.0.0.1