### PR TITLE
removed masscan's need for sudo on every execution

### DIFF
--- a/recon-pipeline.py
+++ b/recon-pipeline.py
@@ -170,7 +170,7 @@ class ReconShell(cmd2.Cmd):
             # name for the option came from @AlphaRingo
             command.pop(command.index("--sausage"))
 
-            webbrowser.open("localhost:8082")  # hard-coded here, can specify different with the status command
+            webbrowser.open("127.0.0.1:8082")  # hard-coded here, can specify different with the status command
 
         if args.verbose:
             # verbose is not a luigi option, need to remove it

--- a/recon/__init__.py
+++ b/recon/__init__.py
@@ -40,6 +40,7 @@ tools = {
             "make -s -j -C /tmp/masscan",
             f"mv /tmp/masscan/bin/masscan {tool_paths.get('masscan')}",
             "rm -rf /tmp/masscan",
+            f"sudo setcap CAP_NET_RAW+ep {tool_paths.get('masscan')}",
         ],
     },
     "amass": {


### PR DESCRIPTION
`install masscan` now adds CAP_NET_RAW linux capability to masscan

this removes the need to run sudo each time masscan is run

closes #21