### PR TITLE
Update go download host

### DIFF
--- a/pipeline/tools/loader.py
+++ b/pipeline/tools/loader.py
@@ -46,7 +46,7 @@ def get_go_version(loader=None, node=None):
     arch = defaults.get("arch")
     err_msg = "Could not find latest go version download url"
 
-    conn = client.HTTPSConnection("golang.org")
+    conn = client.HTTPSConnection("go.dev")
     conn.request("GET", "/dl/")
     response = conn.getresponse().read().decode()
 


### PR DESCRIPTION
The go download host has changed, causing a 301 redirect response which generates an error in the go installation. This commit updates the host in the HTTPS request to avoid such error, more info in https://github.com/epi052/recon-pipeline/issues/105

# Landing a Pull Request (PR)

Long-form explanations of most of the items below can be found in the [CONTRIBUTING](https://github.com/epi052/recon-pipeline/blob/master/CONTRIBUTING.md) guide.

## Branching checklist
- [x] There is an issue associated with your PR (bug, feature, etc.. if not, create one)
- [x] Your PR description references the associated issue (i.e. fixes #123)
- [x] Code is in its branch
- [x] Branch name is related to the PR contents
- [x] PR targets master

## Static analysis checks
- [x] All python files are formatted using black
- [x] All flake8 checks pass
- [x] All existing tests pass

## Documentation
- [x] Documentation about your PR is included in docs/ and the README, as appropriate

## Additional Tests
- [x] New code is unit tested
- [x] New tests pass
