### PR TITLE
Fix amass installation command

### DIFF
--- a/pipeline/tools/amass.yaml
+++ b/pipeline/tools/amass.yaml
@@ -4,7 +4,7 @@ path: &path !join_path [!get_default "{gopath}", "bin/amass"]
 environ: {"GO111MODULE": "on", "GOPATH": !get_default "{gopath}"}
 
 install_commands:
-- !join [*gotool, get github.com/OWASP/Amass/v3/...]
+- !join [*gotool, install -v github.com/OWASP/Amass/v3/...@master]
 
 uninstall_commands:
 - !join [rm, *path]


### PR DESCRIPTION
The installation command for amass no longer works. This commit is intended to update it to the newer recommended way to install amass (from the official repository/docs), so the installation runs smoothly.
