### PR TITLE
fix go install command for tools

### DIFF
--- a/pipeline/tools/gobuster.yaml
+++ b/pipeline/tools/gobuster.yaml
@@ -5,7 +5,7 @@ environ: {"GOPATH": !get_default "{gopath}"}
 home: &home !get_default "{home}"
 
 install_commands:
-- !join [*gotool, get github.com/OJ/gobuster]
+- !join [*gotool, install github.com/OJ/gobuster@latest]
 
 uninstall_commands:
 - !join [rm, *path]

--- a/pipeline/tools/subjack.yaml
+++ b/pipeline/tools/subjack.yaml
@@ -6,7 +6,7 @@ environ: {"GOPATH": !get_default "{gopath}"}
 fingerprints: !join_path [!get_default "{gopath}", src/github.com/haccer/subjack/fingerprints.json]
 
 install_commands:
-- !join [*gotool, get github.com/haccer/subjack]
+- !join [*gotool, install github.com/haccer/subjack@latest]
 
 uninstall_commands:
 - !join [rm, *path]

--- a/pipeline/tools/tko-subs.yaml
+++ b/pipeline/tools/tko-subs.yaml
@@ -5,7 +5,7 @@ environ: {"GOPATH": !get_default "{gopath}"}
 providers: !join_path [!get_default "{gopath}", src/github.com/anshumanbh/tko-subs/providers-data.csv]
 
 install_commands:
-- !join [*gotool, get, github.com/anshumanbh/tko-subs]
+- !join [*gotool, install, github.com/anshumanbh/tko-subs@latest]
 
 uninstall_commands:
 - !join [rm, *path]

--- a/pipeline/tools/waybackurls.yaml
+++ b/pipeline/tools/waybackurls.yaml
@@ -4,7 +4,7 @@ path: &path !join_path [!get_default "{gopath}", bin/waybackurls]
 environ: {"GOPATH": !get_default "{gopath}"}
 
 install_commands:
-- !join [*gotool, get, github.com/tomnomnom/waybackurls]
+- !join [*gotool, install, github.com/tomnomnom/waybackurls@latest]
 
 uninstall_commands:
 - !join [rm, *path]

--- a/pipeline/tools/webanalyze.yaml
+++ b/pipeline/tools/webanalyze.yaml
@@ -4,7 +4,7 @@ path: &path !join_path [!get_default "{gopath}", bin/webanalyze]
 environ: {"GOPATH": !get_default "{gopath}"}
 
 install_commands:
-- !join [*gotool, get github.com/rverton/webanalyze/...]
+- !join [*gotool, install github.com/rverton/webanalyze/...@latest]
 
 uninstall_commands:
 - !join [rm, *path]


### PR DESCRIPTION
these tools were not installing with the error below
- gobuster
- subjack
- tko-subs
- waybackurls
- webanalyze

with this error:
```
[!] go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```